### PR TITLE
fix: Remove backslash from description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Gatsby Cache"
-description: "Cache build outputs for Gatsby\'s Conditional Page Build."
+description: "Cache build outputs for Gatsby's Conditional Page Build."
 author: "jongwooo <jongwooo.han@gmail.com>"
 inputs:
   use-cache:


### PR DESCRIPTION
## Description

Remove backslash(\\) from description.