### PR TITLE
feat: Add inputs for key and restore keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 ### Inputs
 
 - `use-cache` - A boolean value to enable/disable conditional page build.
+- `key` - An explicit key for restoring and saving the cache.
+- `restore-keys` - An ordered list of keys to use for restoring stale cache if no cache hit occurred for key.
 
 ### Outputs
 
 - `cache-hit` - A boolean value to indicate an exact match was found for the key.
+
+> Note: `cache-hit` will be set to `true` only when cache hit occurs for the exact `key` match. For a partial key match via `restore-keys` or a cache miss, it will be set to `false`.
 
 ### Cache Details
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,12 @@ inputs:
     description: "A boolean value to enable/disable conditional page build."
     required: false
     default: true
+  key:
+    description: "An explicit key for restoring and saving the cache."
+    required: false
+  restore-keys:
+    description: "An ordered list of keys to use for restoring stale cache if no cache hit occurred for key."
+    required: false
 outputs:
   cache-hit:
     description: "A boolean value to indicate an exact match was found for the key."

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -64141,6 +64141,8 @@ exports.State = exports.Outputs = exports.Inputs = void 0;
 var Inputs;
 (function (Inputs) {
     Inputs["UseCache"] = "use-cache";
+    Inputs["Key"] = "key";
+    Inputs["RestoreKeys"] = "restore-keys";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -64194,19 +64196,21 @@ async function run() {
             utils.setCacheHitOutput(false);
             return;
         }
-        const useCache = core.getBooleanInput(constants_1.Inputs.UseCache);
-        utils.setBuildMode(useCache);
         const platform = process.env.RUNNER_OS;
         if (!platform) {
             return;
         }
-        const hash = await utils.createHash();
-        const baseKey = `${platform}-gatsby-build-`;
-        const primaryKey = `${baseKey}${hash}`;
+        const useCache = core.getBooleanInput(constants_1.Inputs.UseCache);
+        utils.setBuildMode(useCache);
+        const cachePaths = await utils.getBuildOutputPaths();
+        let primaryKey = core.getInput(constants_1.Inputs.Key);
+        if (!primaryKey) {
+            const fileHash = await utils.createHash();
+            primaryKey = `${platform}-gatsby-build-${fileHash}`;
+        }
         core.debug(`primary key is ${primaryKey}`);
         core.saveState(constants_1.State.CachePrimaryKey, primaryKey);
-        const restoreKeys = [baseKey];
-        const cachePaths = await utils.getBuildOutputPaths();
+        const restoreKeys = utils.getInputAsArray(constants_1.Inputs.RestoreKeys);
         const cacheKey = await cache.restoreCache(cachePaths, primaryKey, restoreKeys);
         if (!cacheKey) {
             core.info(`Cache not found for keys: ${[primaryKey, ...restoreKeys].join(", ")}`);
@@ -64258,7 +64262,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.createHash = exports.getBuildOutputPaths = exports.isCacheFeatureAvailable = exports.logWarning = exports.getCacheState = exports.setCacheHitOutput = exports.setCacheState = exports.setBuildMode = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.createHash = exports.getBuildOutputPaths = exports.getInputAsArray = exports.isCacheFeatureAvailable = exports.logWarning = exports.getCacheState = exports.setCacheHitOutput = exports.setCacheState = exports.setBuildMode = exports.isExactKeyMatch = exports.isGhes = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const glob = __importStar(__nccwpck_require__(8090));
@@ -64320,6 +64324,14 @@ Otherwise please upgrade to GHES version >= 3.5 and If you are also using Github
     return true;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
+function getInputAsArray(name, options) {
+    return core
+        .getInput(name, options)
+        .split("\n")
+        .map((s) => s.replace(/^!\s+/, "!").trim())
+        .filter((x) => x !== "");
+}
+exports.getInputAsArray = getInputAsArray;
 async function getBuildOutputPaths() {
     const targetPaths = [".cache", "public"];
     const buildOutputPaths = [];

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -64141,6 +64141,8 @@ exports.State = exports.Outputs = exports.Inputs = void 0;
 var Inputs;
 (function (Inputs) {
     Inputs["UseCache"] = "use-cache";
+    Inputs["Key"] = "key";
+    Inputs["RestoreKeys"] = "restore-keys";
 })(Inputs = exports.Inputs || (exports.Inputs = {}));
 var Outputs;
 (function (Outputs) {
@@ -64251,7 +64253,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.createHash = exports.getBuildOutputPaths = exports.isCacheFeatureAvailable = exports.logWarning = exports.getCacheState = exports.setCacheHitOutput = exports.setCacheState = exports.setBuildMode = exports.isExactKeyMatch = exports.isGhes = void 0;
+exports.createHash = exports.getBuildOutputPaths = exports.getInputAsArray = exports.isCacheFeatureAvailable = exports.logWarning = exports.getCacheState = exports.setCacheHitOutput = exports.setCacheState = exports.setBuildMode = exports.isExactKeyMatch = exports.isGhes = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const glob = __importStar(__nccwpck_require__(8090));
@@ -64313,6 +64315,14 @@ Otherwise please upgrade to GHES version >= 3.5 and If you are also using Github
     return true;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
+function getInputAsArray(name, options) {
+    return core
+        .getInput(name, options)
+        .split("\n")
+        .map((s) => s.replace(/^!\s+/, "!").trim())
+        .filter((x) => x !== "");
+}
+exports.getInputAsArray = getInputAsArray;
 async function getBuildOutputPaths() {
     const targetPaths = [".cache", "public"];
     const buildOutputPaths = [];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export enum Inputs {
   UseCache = "use-cache",
+  Key = "key",
+  RestoreKeys = "restore-keys",
 }
 
 export enum Outputs {

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -70,6 +70,17 @@ Otherwise please upgrade to GHES version >= 3.5 and If you are also using Github
   return true;
 }
 
+export function getInputAsArray(
+  name: string,
+  options?: core.InputOptions
+): string[] {
+  return core
+    .getInput(name, options)
+    .split("\n")
+    .map((s) => s.replace(/^!\s+/, "!").trim())
+    .filter((x) => x !== "");
+}
+
 export async function getBuildOutputPaths(): Promise<string[]> {
   const targetPaths: string[] = [".cache", "public"];
   const buildOutputPaths: string[] = [];


### PR DESCRIPTION
## Description

Add inputs for `key` and `restore-keys`.

- `key` - An explicit key for restoring and saving the cache.
- `restore-keys` - An ordered list of keys to use for restoring stale cache if no cache hit occurred for key.
