### PR TITLE
chore: Update prettier to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint": "^8.27.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.0",
         "typescript": "^4.8.4"
       }
     },
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^8.27.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.0",
     "typescript": "^4.8.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Cache build outputs for Gatsby's Conditional Page Build",
   "author": "jongwooo <jongwooo.han@gmail.com>",
   "scripts": {
-    "format": "prettier --write 'src/**/*.ts'",
+    "format": "prettier --check 'src/**/*.ts'",
+	"format:fix": "prettier --write 'src/**/*.ts'",
     "lint": "tsc --noEmit && eslint 'src/**/*.ts'",
     "build": "ncc build -o dist/restore src/restore.ts && ncc build -o dist/save src/save.ts"
   },


### PR DESCRIPTION
## Description

- Updated prettier from [v2.7.1](https://github.com/prettier/prettier/releases/tag/2.7.1) to [v2.8.0](https://github.com/prettier/prettier/releases/tag/2.8.0).
- Added `format:fix` script