### PR TITLE
chore: Release v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-cache",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-cache",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-cache",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cache build outputs for Gatsby's Conditional Page Build",
   "author": "jongwooo <jongwooo.han@gmail.com>",
   "scripts": {


### PR DESCRIPTION
## What's Changed
* chore: Use Dependabot security updates by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/28
* chore(deps-dev): Bump @typescript-eslint/parser from 5.44.0 to 5.45.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/29
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.44.0 to 5.45.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/30
* chore: Specify workflow node version as v16 by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/31
* chore: Add github-actions ecosystem for dependabot by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/32
* chore: Compare the expected and actual dist/ directories by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/33
* fix: Replace double quotes with single quotes by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/34
* docs: Remove PR status badge from README.md by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/35
* chore: Add check-commit-messages workflow by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/36
* chore: Add new commit prefix types by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/37
* chore(deps-dev): Bump @types/node from 18.11.9 to 18.11.10 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/38
* ci: Separate workflows by function by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/39

## New Contributors
* @dependabot made their first contribution in https://github.com/jongwooo/gatsby-cache/pull/29

**Full Changelog**: https://github.com/jongwooo/gatsby-cache/compare/v1.2.0...v1.2.1