### PR TITLE
chore: Release v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-cache",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-cache",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-cache",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Cache build outputs for Gatsby's Conditional Page Build",
   "author": "jongwooo <jongwooo.han@gmail.com>",
   "scripts": {


### PR DESCRIPTION
## What's Changed
* chore(deps-dev): Bump @types/node from 18.11.13 to 18.11.14 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/65
* refactor: Move scripts to `.github` by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/66
* chore(deps-dev): Bump @types/node from 18.11.14 to 18.11.15 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/67
* chore(deps-dev): Bump @types/node from 18.11.15 to 18.11.16 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/68
* chore(deps-dev): Bump eslint from 8.29.0 to 8.30.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/69
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.46.1 to 5.47.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/70
* fix: Remove unescaped forward slash by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/73
* chore(deps-dev): Bump @types/node from 18.11.16 to 18.11.17 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/71
* chore(deps-dev): Bump @typescript-eslint/parser from 5.46.1 to 5.47.0 by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/74
* ci: Add new commit message type by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/75


**Full Changelog**: https://github.com/jongwooo/gatsby-cache/compare/v1.2.2...v1.2.3