### PR TITLE
chore: Use paths-ignore instead of paths trigger

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-    paths:
-      - src/**/*.ts
+    paths-ignore:
+      - '**.md'
   pull_request:
-    paths:
-      - src/**/*.ts
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Use `paths-ignore` instead of `paths` trigger.