### PR TITLE
Use type inference instead of explicit type declarations

### DIFF
--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -63171,7 +63171,7 @@ const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const utils = __importStar(__nccwpck_require__(6850));
 const constants_1 = __nccwpck_require__(9042);
-process.on("uncaughtException", (error) => utils.logWarning(error.message));
+process.on("uncaughtException", (e) => utils.logWarning(e.message));
 async function saveImpl(stateProvider) {
     let cacheId = -1;
     try {

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -16,7 +16,7 @@ async function restoreImpl(
     }
 
     if (!utils.isValidEvent()) {
-      const eventName: string = process.env[Events.Key] || "";
+      const eventName = process.env[Events.Key] || "";
       utils.logWarning(
         `Event Validation Error: The event type ${eventName} is not supported because it's not tied to a branch or tag ref.`
       );
@@ -25,12 +25,12 @@ async function restoreImpl(
 
     utils.setConditionalPageBuild();
 
-    const cachePaths: string[] = await utils.getBuildOutputPaths();
-    const restoreKeys: string[] = utils.getInputAsArray(Inputs.RestoreKeys);
+    const cachePaths = await utils.getBuildOutputPaths();
+    const restoreKeys = utils.getInputAsArray(Inputs.RestoreKeys);
 
-    let primaryKey: string = core.getInput(Inputs.Key);
+    let primaryKey = core.getInput(Inputs.Key);
     if (!primaryKey) {
-      const platform: Runner = process.env[Platform.RunnerOs] as Runner;
+      const platform = process.env[Platform.RunnerOs] as Runner;
       primaryKey = `${platform}-gatsby-build-`;
     }
 
@@ -53,10 +53,7 @@ async function restoreImpl(
 
     stateProvider.setState(State.CacheMatchedKey, cacheKey);
 
-    const isExactKeyMatch: boolean = utils.isExactKeyMatch(
-      primaryKey,
-      cacheKey
-    );
+    const isExactKeyMatch = utils.isExactKeyMatch(primaryKey, cacheKey);
 
     core.setOutput(Outputs.CacheHit, isExactKeyMatch.toString());
     core.info(`Cache restored from key: ${cacheKey}`);

--- a/src/saveImpl.ts
+++ b/src/saveImpl.ts
@@ -4,9 +4,7 @@ import * as utils from "./utils/actionUtils";
 import { Inputs, State } from "./constants";
 import { BaseStateProvider } from "./stateProvider";
 
-process.on("uncaughtException", (error: unknown) =>
-  utils.logWarning((error as Error).message)
-);
+process.on("uncaughtException", (e) => utils.logWarning(e.message));
 
 async function saveImpl(
   stateProvider: BaseStateProvider
@@ -17,9 +15,9 @@ async function saveImpl(
       return;
     }
 
-    const state: string | undefined = stateProvider.getCacheState();
+    const state = stateProvider.getCacheState();
 
-    const primaryKey: string =
+    const primaryKey =
       stateProvider.getState(State.CachePrimaryKey) ||
       core.getInput(Inputs.Key);
 
@@ -35,7 +33,7 @@ async function saveImpl(
       return;
     }
 
-    const cachePaths: string[] = await utils.getBuildOutputPaths();
+    const cachePaths = await utils.getBuildOutputPaths();
     cacheId = await cache.saveCache(cachePaths, primaryKey);
 
     if (cacheId != -1) {

--- a/src/stateProvider.ts
+++ b/src/stateProvider.ts
@@ -9,7 +9,7 @@ export interface BaseStateProvider {
 
 export class StateProvider implements BaseStateProvider {
   getCacheState(): string | undefined {
-    const cacheKey: string = this.getState(State.CacheMatchedKey);
+    const cacheKey = this.getState(State.CacheMatchedKey);
     if (cacheKey) {
       core.debug(`Cache state/key: ${cacheKey}`);
       return cacheKey;

--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -4,8 +4,8 @@ import path from "path";
 import { Gatsby, RefKey } from "../constants";
 
 export function isGhes(): boolean {
-  const url: string = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const ghUrl: URL = new URL(url);
+  const url = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+  const ghUrl = new URL(url);
   return ghUrl.hostname.toUpperCase() !== "GITHUB.COM";
 }
 
@@ -63,8 +63,8 @@ export function setConditionalPageBuild(): void {
 }
 
 export async function getBuildOutputPaths(): Promise<string[]> {
-  const targetPaths: string[] = [Gatsby.CacheDir, Gatsby.PublicDir];
-  const buildOutputPaths: string[] = [];
+  const targetPaths = [Gatsby.CacheDir, Gatsby.PublicDir];
+  const buildOutputPaths = [];
 
   for await (const target of targetPaths) {
     buildOutputPaths.push(path.join(process.cwd(), target));


### PR DESCRIPTION
## Description

Resolve #105 

> **Note** Declaring types for all variables is counterproductive and considered poor style.

Change to use type inference instead of explicit type declarations.

**AS-IS**

```ts
const cacheKey: string = this.getState(State.CacheMatchedKey);
```

**TO-BE**

```ts
const cacheKey = this.getState(State.CacheMatchedKey);
```

## References

- [Item 19: Avoid Cluttering Your Code with Inferable Types](https://effectivetypescript.com/2020/04/28/avoid-inferable/)