### PR TITLE
chore: Release v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-cache",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-cache",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-cache",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Cache build outputs for Gatsby's Conditional Page Build",
   "author": "jongwooo <jongwooo.han@gmail.com>",
   "scripts": {


### PR DESCRIPTION
## What's Changed
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.47.0 to 5.47.1 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/85
* chore(deps-dev): Bump @typescript-eslint/parser from 5.47.0 to 5.47.1 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/86
* chore(deps-dev): Bump @types/node from 18.11.17 to 18.11.18 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/87
* chore(deps): Bump @actions/cache from 3.1.0 to 3.1.1 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/88
* chore(deps-dev): Bump eslint from 8.30.0 to 8.31.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/92
* chore(deps-dev): Bump eslint-config-prettier from 8.5.0 to 8.6.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/90
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.47.1 to 5.48.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/93
* chore(deps-dev): Bump @typescript-eslint/parser from 5.47.1 to 5.48.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/91
* chore(deps): Bump @actions/cache from 3.1.1 to 3.1.2 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/94
* chore(deps-dev): Bump prettier from 2.8.1 to 2.8.2 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/96
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.48.0 to 5.48.1 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/95
* chore(deps-dev): Bump @typescript-eslint/parser from 5.48.0 to 5.48.1 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/97
* chore: Bundle files into dist by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/98
* chore: Use paths-ignore instead of paths trigger by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/99
* chore(deps-dev): Bump prettier from 2.8.2 to 2.8.3 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/101
* chore(deps-dev): Bump @typescript-eslint/parser from 5.48.1 to 5.48.2 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/100
* chore(deps-dev): Bump eslint from 8.31.0 to 8.32.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/103
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.48.1 to 5.48.2 by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/104
* refactor: Use type inference instead of explicit type declarations by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/106


**Full Changelog**: https://github.com/jongwooo/gatsby-cache/compare/v1.4.0...v1.4.1