### PR TITLE
chore: Release v1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-cache",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-cache",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-cache",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Cache build outputs for Gatsby's Conditional Page Build",
   "author": "jongwooo <jongwooo.han@gmail.com>",
   "scripts": {


### PR DESCRIPTION
## What's Changed
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.48.2 to 5.49.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/108
* chore(deps-dev): Bump @typescript-eslint/parser from 5.48.2 to 5.49.0 by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/110
* chore(deps): Bump @actions/glob from 0.3.0 to 0.4.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/111
* chore(deps-dev): Bump @vercel/ncc from 0.36.0 to 0.36.1 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/112
* chore(deps-dev): Bump eslint from 8.32.0 to 8.33.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/113
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.49.0 to 5.50.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/114
* chore(deps-dev): Bump typescript from 4.9.4 to 4.9.5 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/115
* chore(deps-dev): Bump @typescript-eslint/parser from 5.49.0 to 5.50.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/116
* chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 5.50.0 to 5.51.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/119
* chore(deps-dev): Bump @types/node from 18.11.18 to 18.13.0 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/120
* chore: Bump @typescript-eslint/parser from 5.50.0 to 5.51.0 by @jongwooo in https://github.com/jongwooo/gatsby-cache/pull/121
* chore(deps-dev): Bump prettier from 2.8.3 to 2.8.4 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/122
* chore(deps): Bump @actions/cache from 3.1.2 to 3.1.3 by @dependabot in https://github.com/jongwooo/gatsby-cache/pull/123


**Full Changelog**: https://github.com/jongwooo/gatsby-cache/compare/v1.4.1...v1.4.2