### PR TITLE
chore: Support grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns:
+          - "actions/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+      eslint:
+        patterns:
+          - "eslint*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

This feature was just recently released:
https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/